### PR TITLE
Added HTTPS support as git protocol

### DIFF
--- a/client/src/main/java/com/innovarhealthcare/channelHistory/client/dialog/GitSettingsDialog.java
+++ b/client/src/main/java/com/innovarhealthcare/channelHistory/client/dialog/GitSettingsDialog.java
@@ -2,6 +2,7 @@ package com.innovarhealthcare.channelHistory.client.dialog;
 
 import com.innovarhealthcare.channelHistory.shared.interfaces.ChannelHistoryServletInterface;
 import com.innovarhealthcare.channelHistory.shared.model.GitSettings;
+import com.innovarhealthcare.channelHistory.shared.model.TransportType;
 import com.innovarhealthcare.channelHistory.shared.model.VersionHistoryProperties;
 
 import com.mirth.connect.client.core.Client;
@@ -10,7 +11,10 @@ import com.mirth.connect.client.ui.MirthDialog;
 import com.mirth.connect.client.ui.PlatformUI;
 import com.mirth.connect.client.ui.UIConstants;
 
+import javax.swing.ButtonGroup;
 import javax.swing.JLabel;
+import javax.swing.JPasswordField;
+import javax.swing.JRadioButton;
 import javax.swing.JTextField;
 import javax.swing.JTextArea;
 import javax.swing.JScrollPane;
@@ -35,10 +39,21 @@ public class GitSettingsDialog extends MirthDialog {
     private JLabel branchNameLabel;
     private JTextField branchNameField;
 
+    private JLabel transportTypeLabel;
+    private JRadioButton sshRadioButton;
+    private JRadioButton httpsRadioButton;
+    private ButtonGroup transportTypeGroup;
+
     private JLabel sshPrivateKeyLabel;
     private JTextArea sshPrivateKeyField;
     private JScrollPane sshKeyScrollPane;
     private JButton loadButton;
+
+    private JLabel httpsUsernameLabel;
+    private JTextField httpsUsernameField;
+
+    private JLabel httpsPatLabel;
+    private JPasswordField httpsPatField;
 
     private JButton saveButton;
     private JButton cancelButton;
@@ -71,11 +86,23 @@ public class GitSettingsDialog extends MirthDialog {
 
         remoteRepositoryUrlLabel = new JLabel("Remote Repository Url:");
         remoteRepositoryUrlField = new JTextField();
-        remoteRepositoryUrlField.setToolTipText("Enter an SSH URL for the remote Git repository (e.g., git@github.com:user/repo.git).");
+        remoteRepositoryUrlField.setToolTipText("Enter the remote Git repository URL.");
 
         branchNameLabel = new JLabel("Branch Name:");
         branchNameField = new JTextField();
         branchNameField.setToolTipText("Enter the branch name to use (e.g., main, develop, or feature/xyz).");
+
+        transportTypeLabel = new JLabel("Transport Type:");
+        sshRadioButton = new JRadioButton("SSH");
+        sshRadioButton.setBackground(UIConstants.BACKGROUND_COLOR);
+        sshRadioButton.addActionListener(evt -> updateTransportTypeFields());
+        httpsRadioButton = new JRadioButton("HTTPS");
+        httpsRadioButton.setBackground(UIConstants.BACKGROUND_COLOR);
+        httpsRadioButton.addActionListener(evt -> updateTransportTypeFields());
+        transportTypeGroup = new ButtonGroup();
+        transportTypeGroup.add(sshRadioButton);
+        transportTypeGroup.add(httpsRadioButton);
+        sshRadioButton.setSelected(true);
 
         sshPrivateKeyLabel = new JLabel("SSH Private Key:");
         sshPrivateKeyField = new JTextArea();
@@ -88,6 +115,14 @@ public class GitSettingsDialog extends MirthDialog {
 
         loadButton = new JButton("Load");
         loadButton.addActionListener(evt -> loadPrivateKey());
+
+        httpsUsernameLabel = new JLabel("Username:");
+        httpsUsernameField = new JTextField();
+        httpsUsernameField.setToolTipText("Enter your Git username for HTTPS authentication.");
+
+        httpsPatLabel = new JLabel("Personal Access Token:");
+        httpsPatField = new JPasswordField();
+        httpsPatField.setToolTipText("Enter your Personal Access Token (PAT) for HTTPS authentication.");
 
         saveButton = new JButton("Save");
         saveButton.addActionListener(evt -> save());
@@ -108,15 +143,40 @@ public class GitSettingsDialog extends MirthDialog {
         add(branchNameLabel, "newline, right");
         add(branchNameField, "w 100!");
 
+        add(transportTypeLabel, "newline, right");
+        add(sshRadioButton, "split 2");
+        add(httpsRadioButton);
+
         add(sshPrivateKeyLabel, "newline, right");
         add(sshKeyScrollPane);
         add(loadButton, "right");
+
+        add(httpsUsernameLabel, "newline, right");
+        add(httpsUsernameField, "w 200!");
+
+        add(httpsPatLabel, "newline, right");
+        add(httpsPatField, "w 300!");
 
         add(new JSeparator(), "newline, sx, growx");
 
         add(saveButton, "newline, sx, right, split 3");
         add(cancelButton);
         add(validateButton);
+    }
+
+    private void updateTransportTypeFields() {
+        boolean isSsh = sshRadioButton.isSelected();
+
+        sshPrivateKeyLabel.setVisible(isSsh);
+        sshKeyScrollPane.setVisible(isSsh);
+        loadButton.setVisible(isSsh);
+
+        httpsUsernameLabel.setVisible(!isSsh);
+        httpsUsernameField.setVisible(!isSsh);
+        httpsPatLabel.setVisible(!isSsh);
+        httpsPatField.setVisible(!isSsh);
+
+        pack();
     }
 
     private void resetComponents() {
@@ -128,7 +188,18 @@ public class GitSettingsDialog extends MirthDialog {
 
         remoteRepositoryUrlField.setText(settings.getRemoteRepositoryUrl());
         branchNameField.setText(settings.getBranchName());
+
+        if (settings.getTransportType() == TransportType.HTTPS) {
+            httpsRadioButton.setSelected(true);
+        } else {
+            sshRadioButton.setSelected(true);
+        }
+
         sshPrivateKeyField.setText(settings.getSshPrivateKey());
+        httpsUsernameField.setText(settings.getHttpsUsername());
+        httpsPatField.setText(settings.getHttpsPersonalAccessToken());
+
+        updateTransportTypeFields();
     }
 
     private boolean validateSettings() {
@@ -142,7 +213,7 @@ public class GitSettingsDialog extends MirthDialog {
         if (StringUtils.isEmpty(url)) {
             valid = false;
             remoteRepositoryUrlField.setBackground(UIConstants.INVALID_COLOR);
-            errorMessage.append("Please provide an SSH remote repository URL (e.g., git@github.com:user/repo.git).")
+            errorMessage.append("Please provide a remote repository URL.")
                     .append(System.lineSeparator());
         }
 
@@ -154,12 +225,30 @@ public class GitSettingsDialog extends MirthDialog {
                     .append(System.lineSeparator());
         }
 
-        String sshKey = sshPrivateKeyField.getText().trim();
-        if (StringUtils.isEmpty(sshKey)) {
-            valid = false;
-            sshPrivateKeyField.setBackground(UIConstants.INVALID_COLOR);
-            errorMessage.append("Please provide an SSH private key (starts with '-----BEGIN').")
-                    .append(System.lineSeparator());
+        if (sshRadioButton.isSelected()) {
+            String sshKey = sshPrivateKeyField.getText().trim();
+            if (StringUtils.isEmpty(sshKey)) {
+                valid = false;
+                sshPrivateKeyField.setBackground(UIConstants.INVALID_COLOR);
+                errorMessage.append("Please provide an SSH private key (starts with '-----BEGIN').")
+                        .append(System.lineSeparator());
+            }
+        } else {
+            String username = httpsUsernameField.getText().trim();
+            if (StringUtils.isEmpty(username)) {
+                valid = false;
+                httpsUsernameField.setBackground(UIConstants.INVALID_COLOR);
+                errorMessage.append("Please provide a username for HTTPS authentication.")
+                        .append(System.lineSeparator());
+            }
+
+            String pat = new String(httpsPatField.getPassword()).trim();
+            if (StringUtils.isEmpty(pat)) {
+                valid = false;
+                httpsPatField.setBackground(UIConstants.INVALID_COLOR);
+                errorMessage.append("Please provide a Personal Access Token (PAT) for HTTPS authentication.")
+                        .append(System.lineSeparator());
+            }
         }
 
         if (!valid) {
@@ -195,6 +284,8 @@ public class GitSettingsDialog extends MirthDialog {
         remoteRepositoryUrlField.setBackground(null);
         branchNameField.setBackground(null);
         sshPrivateKeyField.setBackground(null);
+        httpsUsernameField.setBackground(null);
+        httpsPatField.setBackground(null);
     }
 
     private void save() {
@@ -204,7 +295,15 @@ public class GitSettingsDialog extends MirthDialog {
 
         gitSettings.setRemoteRepositoryUrl(remoteRepositoryUrlField.getText().trim());
         gitSettings.setBranchName(branchNameField.getText().trim());
-        gitSettings.setSshPrivateKey(sshPrivateKeyField.getText().trim());
+
+        if (sshRadioButton.isSelected()) {
+            gitSettings.setTransportType(TransportType.SSH);
+            gitSettings.setSshPrivateKey(sshPrivateKeyField.getText().trim());
+        } else {
+            gitSettings.setTransportType(TransportType.HTTPS);
+            gitSettings.setHttpsUsername(httpsUsernameField.getText().trim());
+            gitSettings.setHttpsPersonalAccessToken(new String(httpsPatField.getPassword()).trim());
+        }
 
         PlatformUI.MIRTH_FRAME.setSaveEnabled(true);
 
@@ -215,7 +314,6 @@ public class GitSettingsDialog extends MirthDialog {
         Properties properties = new Properties();
         String url = remoteRepositoryUrlField.getText().trim();
         String branch = branchNameField.getText().trim();
-        String sshKey = sshPrivateKeyField.getText().trim();
 
         if (!StringUtils.isEmpty(url)) {
             properties.setProperty(VersionHistoryProperties.VERSION_HISTORY_REMOTE_REPO_URL, url);
@@ -223,8 +321,23 @@ public class GitSettingsDialog extends MirthDialog {
         if (!StringUtils.isEmpty(branch)) {
             properties.setProperty(VersionHistoryProperties.VERSION_HISTORY_REMOTE_BRANCH, branch);
         }
-        if (!StringUtils.isEmpty(sshKey)) {
-            properties.setProperty(VersionHistoryProperties.VERSION_HISTORY_REMOTE_SSH_KEY, sshKey);
+
+        if (sshRadioButton.isSelected()) {
+            properties.setProperty(VersionHistoryProperties.VERSION_HISTORY_TRANSPORT_TYPE, TransportType.SSH.name());
+            String sshKey = sshPrivateKeyField.getText().trim();
+            if (!StringUtils.isEmpty(sshKey)) {
+                properties.setProperty(VersionHistoryProperties.VERSION_HISTORY_REMOTE_SSH_KEY, sshKey);
+            }
+        } else {
+            properties.setProperty(VersionHistoryProperties.VERSION_HISTORY_TRANSPORT_TYPE, TransportType.HTTPS.name());
+            String username = httpsUsernameField.getText().trim();
+            String pat = new String(httpsPatField.getPassword()).trim();
+            if (!StringUtils.isEmpty(username)) {
+                properties.setProperty(VersionHistoryProperties.VERSION_HISTORY_HTTPS_USERNAME, username);
+            }
+            if (!StringUtils.isEmpty(pat)) {
+                properties.setProperty(VersionHistoryProperties.VERSION_HISTORY_HTTPS_PAT, pat);
+            }
         }
 
         return properties;

--- a/pom.xml
+++ b/pom.xml
@@ -404,6 +404,18 @@
         <!-- Version 4.6.0 -->
         <profile>
             <id>v460</id>
+            <properties>
+                <maven.compiler.source>17</maven.compiler.source>
+                <maven.compiler.target>17</maven.compiler.target>
+
+                <mirth.version>4.6.0</mirth.version>
+                <plugin.mirthVersion>${mirth.version}</plugin.mirthVersion>
+                <plugin.archive.name>innovarhealthcare-channel-history-arch-${mirth.version}</plugin.archive.name>
+            </properties>
+        </profile>
+        <!-- Version 4.6.1 -->
+        <profile>
+            <id>v461</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
@@ -411,7 +423,7 @@
                 <maven.compiler.source>17</maven.compiler.source>
                 <maven.compiler.target>17</maven.compiler.target>
 
-                <mirth.version>4.6.0</mirth.version>
+                <mirth.version>4.6.1</mirth.version>
                 <plugin.mirthVersion>${mirth.version}</plugin.mirthVersion>
                 <plugin.archive.name>innovarhealthcare-channel-history-arch-${mirth.version}</plugin.archive.name>
             </properties>

--- a/server/src/main/java/com/innovarhealthcare/channelHistory/server/service/GitRepositoryService.java
+++ b/server/src/main/java/com/innovarhealthcare/channelHistory/server/service/GitRepositoryService.java
@@ -2,6 +2,7 @@ package com.innovarhealthcare.channelHistory.server.service;
 
 import com.innovarhealthcare.channelHistory.shared.VersionControlConstants;
 
+import com.innovarhealthcare.channelHistory.shared.model.TransportType;
 import com.innovarhealthcare.channelHistory.shared.model.VersionHistoryProperties;
 import com.innovarhealthcare.channelHistory.shared.util.ResponseUtil;
 import com.jcraft.jsch.JSch;
@@ -40,6 +41,8 @@ import org.eclipse.jgit.transport.SshTransport;
 import org.eclipse.jgit.transport.RefSpec;
 import org.eclipse.jgit.transport.FetchResult;
 import org.eclipse.jgit.transport.URIish;
+import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
+import org.eclipse.jgit.transport.CredentialsProvider;
 import org.eclipse.jgit.transport.PushResult;
 import org.eclipse.jgit.transport.RemoteRefUpdate;
 import org.eclipse.jgit.treewalk.TreeWalk;
@@ -81,8 +84,12 @@ public class GitRepositoryService {
     private boolean autoCommit;
     private String remoteRepoUrl;
     private String remoteRepoBranch;
+    private TransportType transportType;
     private byte[] sshKeyBytes = new byte[0];
     private SshSessionFactory sshSessionFactory;
+    private String httpsUsername;
+    private String httpsPersonalAccessToken;
+    private CredentialsProvider credentialsProvider;
 
     private ChannelService channelService;
     private CodeTemplateService codeTemplateService;
@@ -107,7 +114,7 @@ public class GitRepositoryService {
         dir = new File(Donkey.getInstance().getConfiguration().getAppData(), DATA_DIR);
 
         if (enable) {
-            if (validateGitConnected(remoteRepoUrl, remoteRepoBranch, sshKeyBytes) == null) {
+            if (validateConnection() == null) {
                 initGitRepo(false);
             }
         }
@@ -137,6 +144,14 @@ public class GitRepositoryService {
         return sshSessionFactory;
     }
 
+    public TransportType getTransportType() {
+        return transportType;
+    }
+
+    public CredentialsProvider getCredentialsProvider() {
+        return credentialsProvider;
+    }
+
     public VersionHistoryProperties getVersionHistoryProperties() {
         return versionHistoryProperties;
     }
@@ -148,7 +163,7 @@ public class GitRepositoryService {
         closeGit();
 
         if (enable) {
-            if (validateGitConnected(remoteRepoUrl, remoteRepoBranch, sshKeyBytes) == null) {
+            if (validateConnection() == null) {
                 initGitRepo(true);
             }
         }
@@ -157,11 +172,19 @@ public class GitRepositoryService {
     public String validateSettings(Properties properties) throws Exception {
         VersionHistoryProperties props = new VersionHistoryProperties(properties);
 
-        byte[] ssh = props.getGitSettings().getSshPrivateKey().getBytes(CHARSET_UTF_8);
         String url = props.getGitSettings().getRemoteRepositoryUrl();
         String branch = props.getGitSettings().getBranchName();
+        TransportType type = props.getGitSettings().getTransportType();
 
-        String ret = validateGitConnected(url, branch, ssh);
+        String ret;
+        if (type == TransportType.HTTPS) {
+            String username = props.getGitSettings().getHttpsUsername();
+            String pat = props.getGitSettings().getHttpsPersonalAccessToken();
+            ret = validateGitConnectedHttps(url, branch, username, pat);
+        } else {
+            byte[] ssh = props.getGitSettings().getSshPrivateKey().getBytes(CHARSET_UTF_8);
+            ret = validateGitConnectedSsh(url, branch, ssh);
+        }
 
         if (ret == null) {
             return "Successfully connected to the remote repository. Remember to save your changes.";
@@ -170,7 +193,15 @@ public class GitRepositoryService {
         return ret;
     }
 
-    private String validateGitConnected(String url, String branch, byte[] ssh) {
+    private String validateConnection() {
+        if (transportType == TransportType.HTTPS) {
+            return validateGitConnectedHttps(remoteRepoUrl, remoteRepoBranch, httpsUsername, httpsPersonalAccessToken);
+        } else {
+            return validateGitConnectedSsh(remoteRepoUrl, remoteRepoBranch, sshKeyBytes);
+        }
+    }
+
+    private String validateGitConnectedSsh(String url, String branch, byte[] ssh) {
         SshSessionFactory sshSession = new JschConfigSessionFactory() {
             @Override
             protected void configure(OpenSshConfig.Host host, Session session) {
@@ -189,7 +220,7 @@ public class GitRepositoryService {
         try {
             tempDir = FileUtils.createTempDir("version_history_", "", new File(Donkey.getInstance().getConfiguration().getAppData(), "temp"));
         } catch (Exception e) {
-            logger.warn("Failed to create temp directory. Error: " + e);
+            logger.warn("Failed to create temp directory. Error: {}", e.getMessage());
             return "Failed to create temp directory. Error: " + e;
         }
 
@@ -217,7 +248,42 @@ public class GitRepositoryService {
         try {
             FileUtils.delete(tempDir, 13);
         } catch (Exception e) {
-            logger.warn("Failed to remove temp directory. Error: " + e);
+            logger.warn("Failed to remove temp directory. Error: {}", e.getMessage());
+        }
+
+        return ret;
+    }
+
+    private String validateGitConnectedHttps(String url, String branch, String username, String pat) {
+        File tempDir;
+        try {
+            tempDir = FileUtils.createTempDir("version_history_", "", new File(Donkey.getInstance().getConfiguration().getAppData(), "temp"));
+        } catch (Exception e) {
+            logger.warn("Failed to create temp directory. Error: {}", e.getMessage());
+            return "Failed to create temp directory. Error: " + e;
+        }
+
+        CredentialsProvider credentials = new UsernamePasswordCredentialsProvider(username, pat);
+
+        CloneCommand cloneCommand = Git.cloneRepository();
+        cloneCommand.setURI(url);
+        cloneCommand.setDirectory(tempDir);
+        cloneCommand.setBranch(branch);
+        cloneCommand.setCredentialsProvider(credentials);
+        cloneCommand.setNoCheckout(true);
+
+        String ret = null;
+        try {
+            Git git = cloneCommand.call();
+            git.close();
+        } catch (Exception e) {
+            ret = "Failed to connect to the remote repository. Error: " + e;
+        }
+
+        try {
+            FileUtils.delete(tempDir, 13);
+        } catch (Exception e) {
+            logger.warn("Failed to remove temp directory. Error: {}", e.getMessage());
         }
 
         return ret;
@@ -225,20 +291,25 @@ public class GitRepositoryService {
 
     public void initGitRepo(boolean force) throws Exception {
         try {
-            // init ssh session
-            sshSessionFactory = new JschConfigSessionFactory() {
-                @Override
-                protected void configure(OpenSshConfig.Host host, Session session) {
-                    session.setConfig("StrictHostKeyChecking", "no");
-                }
+            if (transportType == TransportType.HTTPS) {
+                credentialsProvider = new UsernamePasswordCredentialsProvider(httpsUsername, httpsPersonalAccessToken);
+                sshSessionFactory = null;
+            } else {
+                sshSessionFactory = new JschConfigSessionFactory() {
+                    @Override
+                    protected void configure(OpenSshConfig.Host host, Session session) {
+                        session.setConfig("StrictHostKeyChecking", "no");
+                    }
 
-                @Override
-                protected JSch createDefaultJSch(FS fs) throws JSchException {
-                    JSch defaultJSch = super.createDefaultJSch(fs);
-                    defaultJSch.addIdentity("mirthVersionHistoryKey", sshKeyBytes, null, null);
-                    return defaultJSch;
-                }
-            };
+                    @Override
+                    protected JSch createDefaultJSch(FS fs) throws JSchException {
+                        JSch defaultJSch = super.createDefaultJSch(fs);
+                        defaultJSch.addIdentity("mirthVersionHistoryKey", sshKeyBytes, null, null);
+                        return defaultJSch;
+                    }
+                };
+                credentialsProvider = null;
+            }
 
             // init repo directory
             dir = new File(Donkey.getInstance().getConfiguration().getAppData(), DATA_DIR);
@@ -261,6 +332,7 @@ public class GitRepositoryService {
 
             isGitConnected = true;
         } catch (Exception e) {
+            logger.error("Failed to initialize Git repository. Transport: {}, Error: {}", transportType, e.getMessage(), e);
             isGitConnected = false;
         }
     }
@@ -339,8 +411,8 @@ public class GitRepositoryService {
             return responseUtil.fail(operationDetails, "Remote repository URL cannot be empty.");
         }
 
-        if (sshSessionFactory == null) {
-            return responseUtil.fail(operationDetails, "SSH session factory cannot be null.");
+        if (!isTransportConfigured()) {
+            return responseUtil.fail(operationDetails, "Transport not configured (SSH session factory or HTTPS credentials required).");
         }
 
         try {
@@ -377,12 +449,7 @@ public class GitRepositoryService {
                 FetchCommand fetchCommand = git.fetch();
                 fetchCommand.setRemote("origin");
                 fetchCommand.setRefSpecs(new RefSpec("refs/heads/" + branch + ":refs/remotes/origin/" + branch));
-                fetchCommand.setTransportConfigCallback(transport -> {
-                    if (transport instanceof SshTransport) {
-                        SshTransport sshTransport = (SshTransport) transport;
-                        sshTransport.setSshSessionFactory(sshSessionFactory);
-                    }
-                });
+                configureTransport(fetchCommand);
                 FetchResult fetchResult = fetchCommand.call();
                 operationDetails.append("  Fetch: ").append(fetchResult.getMessages()).append(System.lineSeparator());
 
@@ -442,8 +509,8 @@ public class GitRepositoryService {
         if (branch == null || branch.trim().isEmpty()) {
             return responseUtil.fail(operationDetails, "Branch cannot be empty.");
         }
-        if (sshSessionFactory == null) {
-            return responseUtil.fail(operationDetails, "SSH session factory cannot be null.");
+        if (!isTransportConfigured()) {
+            return responseUtil.fail(operationDetails, "Transport not configured (SSH session factory or HTTPS credentials required).");
         }
 
         try {
@@ -488,11 +555,7 @@ public class GitRepositoryService {
             pushCommand.setRemote("origin");
             pushCommand.setRefSpecs(new RefSpec("refs/heads/" + branch));
             pushCommand.setForce(allowForcePush);
-            pushCommand.setTransportConfigCallback(transport -> {
-                if (transport instanceof SshTransport) {
-                    ((SshTransport) transport).setSshSessionFactory(sshSessionFactory);
-                }
-            });
+            configureTransport(pushCommand);
 
             Iterable<PushResult> pushResults = pushCommand.call();
             Iterator<PushResult> iterator = pushResults.iterator();
@@ -565,12 +628,7 @@ public class GitRepositoryService {
         FetchCommand fetchCommand = git.fetch();
         fetchCommand.setRemote("origin");
         fetchCommand.setRefSpecs(new RefSpec("refs/heads/" + branch + ":refs/remotes/origin/" + branch));
-        fetchCommand.setTransportConfigCallback(transport -> {
-            if (transport instanceof SshTransport) {
-                SshTransport sshTransport = (SshTransport) transport;
-                sshTransport.setSshSessionFactory(sshSessionFactory);
-            }
-        });
+        configureTransport(fetchCommand);
         FetchResult fetchResult = fetchCommand.call();
 
         // Get remote and local branch refs
@@ -614,13 +672,7 @@ public class GitRepositoryService {
         PullCommand pullCommand = git.pull();
         pullCommand.setRemote("origin");
         pullCommand.setRemoteBranchName(remoteRepoBranch);
-        pullCommand.setTransportConfigCallback(new TransportConfigCallback() {
-            @Override
-            public void configure(Transport transport) {
-                SshTransport sshTransport = (SshTransport) transport;
-                sshTransport.setSshSessionFactory(sshSessionFactory);
-            }
-        });
+        configureTransport(pullCommand);
         pullCommand.call();
     }
 
@@ -629,28 +681,74 @@ public class GitRepositoryService {
         cloneCommand.setURI(remoteRepoUrl);
         cloneCommand.setDirectory(dir);
         cloneCommand.setBranch(remoteRepoBranch);
-        cloneCommand.setTransportConfigCallback(new TransportConfigCallback() {
-            @Override
-            public void configure(Transport transport) {
-                SshTransport sshTransport = (SshTransport) transport;
-                sshTransport.setSshSessionFactory(sshSessionFactory);
-            }
-        });
-
+        configureTransport(cloneCommand);
         return cloneCommand.call();
+    }
+
+    private void configureTransport(PullCommand command) {
+        if (transportType == TransportType.HTTPS) {
+            command.setCredentialsProvider(credentialsProvider);
+        } else {
+            command.setTransportConfigCallback(transport -> {
+                if (transport instanceof SshTransport) {
+                    ((SshTransport) transport).setSshSessionFactory(sshSessionFactory);
+                }
+            });
+        }
+    }
+
+    private void configureTransport(CloneCommand command) {
+        if (transportType == TransportType.HTTPS) {
+            command.setCredentialsProvider(credentialsProvider);
+        } else {
+            command.setTransportConfigCallback(transport -> {
+                if (transport instanceof SshTransport) {
+                    ((SshTransport) transport).setSshSessionFactory(sshSessionFactory);
+                }
+            });
+        }
+    }
+
+    private void configureTransport(FetchCommand command) {
+        if (transportType == TransportType.HTTPS) {
+            command.setCredentialsProvider(credentialsProvider);
+        } else {
+            command.setTransportConfigCallback(transport -> {
+                if (transport instanceof SshTransport) {
+                    ((SshTransport) transport).setSshSessionFactory(sshSessionFactory);
+                }
+            });
+        }
+    }
+
+    private void configureTransport(PushCommand command) {
+        if (transportType == TransportType.HTTPS) {
+            command.setCredentialsProvider(credentialsProvider);
+        } else {
+            command.setTransportConfigCallback(transport -> {
+                if (transport instanceof SshTransport) {
+                    ((SshTransport) transport).setSshSessionFactory(sshSessionFactory);
+                }
+            });
+        }
+    }
+
+    private boolean isTransportConfigured() {
+        if (transportType == TransportType.HTTPS) {
+            return credentialsProvider != null;
+        } else {
+            return sshSessionFactory != null;
+        }
     }
 
     private void closeGit() {
         if (git != null) {
             git.close();
-
             git = null;
         }
 
-        if (sshSessionFactory != null) {
-            sshSessionFactory = null;
-        }
-
+        sshSessionFactory = null;
+        credentialsProvider = null;
         isGitConnected = false;
     }
 
@@ -678,8 +776,12 @@ public class GitRepositoryService {
         enable = versionHistoryProperties.isEnableVersionHistory();
         autoCommit = versionHistoryProperties.isEnableAutoCommit();
 
-        sshKeyBytes = versionHistoryProperties.getGitSettings().getSshPrivateKey().getBytes(CHARSET_UTF_8);
         remoteRepoUrl = versionHistoryProperties.getGitSettings().getRemoteRepositoryUrl();
         remoteRepoBranch = versionHistoryProperties.getGitSettings().getBranchName();
+        transportType = versionHistoryProperties.getGitSettings().getTransportType();
+
+        sshKeyBytes = versionHistoryProperties.getGitSettings().getSshPrivateKey().getBytes(CHARSET_UTF_8);
+        httpsUsername = versionHistoryProperties.getGitSettings().getHttpsUsername();
+        httpsPersonalAccessToken = versionHistoryProperties.getGitSettings().getHttpsPersonalAccessToken();
     }
 }

--- a/server/src/main/java/com/innovarhealthcare/channelHistory/server/service/ModeService.java
+++ b/server/src/main/java/com/innovarhealthcare/channelHistory/server/service/ModeService.java
@@ -1,6 +1,7 @@
 package com.innovarhealthcare.channelHistory.server.service;
 
 import com.innovarhealthcare.channelHistory.shared.model.CommitMetaData;
+import com.innovarhealthcare.channelHistory.shared.model.TransportType;
 import com.innovarhealthcare.channelHistory.shared.util.ResponseUtil;
 import com.mirth.connect.model.Channel;
 import com.mirth.connect.model.codetemplates.CodeTemplate;
@@ -31,6 +32,7 @@ import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevTree;
 import org.eclipse.jgit.revwalk.RevWalk;
 
+import org.eclipse.jgit.transport.CredentialsProvider;
 import org.eclipse.jgit.transport.SshSessionFactory;
 import org.eclipse.jgit.transport.SshTransport;
 import org.eclipse.jgit.transport.URIish;
@@ -91,6 +93,8 @@ public abstract class ModeService {
         String remoteRepoUrl = this.gitService.getRemoteRepoUrl();
         String branch = this.gitService.getRemoteRepoBranch();
         SshSessionFactory sshSessionFactory = this.gitService.getSshSessionFactory();
+        CredentialsProvider credentialsProvider = this.gitService.getCredentialsProvider();
+        TransportType transportType = this.gitService.getTransportType();
 
         JSONObject result = new JSONObject();
         StringBuilder response = new StringBuilder();
@@ -118,8 +122,14 @@ public abstract class ModeService {
             return responseResultFail(response, "Remote repository URL cannot be empty.");
         }
 
-        if (sshSessionFactory == null) {
-            return responseResultFail(response, "SSH session factory cannot be null.");
+        if (transportType == TransportType.HTTPS) {
+            if (credentialsProvider == null) {
+                return responseResultFail(response, "HTTPS credentials provider cannot be null.");
+            }
+        } else {
+            if (sshSessionFactory == null) {
+                return responseResultFail(response, "SSH session factory cannot be null.");
+            }
         }
 
         if (serializer == null) {
@@ -160,12 +170,15 @@ public abstract class ModeService {
                 FetchCommand fetchCommand = git.fetch();
                 fetchCommand.setRemote("origin");
                 fetchCommand.setRefSpecs(new RefSpec("refs/heads/" + branch + ":refs/remotes/origin/" + branch));
-                fetchCommand.setTransportConfigCallback(transport -> {
-                    if (transport instanceof SshTransport) {
-                        SshTransport sshTransport = (SshTransport) transport;
-                        sshTransport.setSshSessionFactory(sshSessionFactory);
-                    }
-                });
+                if (transportType == TransportType.HTTPS) {
+                    fetchCommand.setCredentialsProvider(credentialsProvider);
+                } else {
+                    fetchCommand.setTransportConfigCallback(transport -> {
+                        if (transport instanceof SshTransport) {
+                            ((SshTransport) transport).setSshSessionFactory(sshSessionFactory);
+                        }
+                    });
+                }
                 FetchResult fetchResult = fetchCommand.call();
                 response.append("  Fetch: ").append(fetchResult.getMessages()).append(System.lineSeparator());
 
@@ -229,12 +242,15 @@ public abstract class ModeService {
             pushCommand.setRemote("origin");
             pushCommand.setRefSpecs(new RefSpec("refs/heads/" + branch));
             pushCommand.setForce(allowForcePush);
-            pushCommand.setTransportConfigCallback(transport -> {
-                if (transport instanceof SshTransport) {
-                    SshTransport sshTransport = (SshTransport) transport;
-                    sshTransport.setSshSessionFactory(sshSessionFactory);
-                }
-            });
+            if (transportType == TransportType.HTTPS) {
+                pushCommand.setCredentialsProvider(credentialsProvider);
+            } else {
+                pushCommand.setTransportConfigCallback(transport -> {
+                    if (transport instanceof SshTransport) {
+                        ((SshTransport) transport).setSshSessionFactory(sshSessionFactory);
+                    }
+                });
+            }
 
             response.append("Push Result:").append(System.lineSeparator());
             Iterable<PushResult> pushResults = pushCommand.call();

--- a/shared/src/main/java/com/innovarhealthcare/channelHistory/shared/model/GitSettings.java
+++ b/shared/src/main/java/com/innovarhealthcare/channelHistory/shared/model/GitSettings.java
@@ -2,17 +2,26 @@ package com.innovarhealthcare.channelHistory.shared.model;
 
 import org.apache.commons.lang3.StringUtils;
 
-import java.util.Objects;
-
 public class GitSettings {
     private String remoteRepositoryUrl;
     private String branchName;
+    private TransportType transportType;
     private String sshPrivateKey;
+    private String httpsUsername;
+    private String httpsPersonalAccessToken;
 
     public GitSettings(String remoteRepositoryUrl, String branchName, String sshPrivateKey) {
+        this(remoteRepositoryUrl, branchName, TransportType.SSH, sshPrivateKey, "", "");
+    }
+
+    public GitSettings(String remoteRepositoryUrl, String branchName, TransportType transportType,
+                       String sshPrivateKey, String httpsUsername, String httpsPersonalAccessToken) {
         this.remoteRepositoryUrl = remoteRepositoryUrl != null ? remoteRepositoryUrl : "";
         this.branchName = branchName != null ? branchName : "";
+        this.transportType = transportType != null ? transportType : TransportType.SSH;
         this.sshPrivateKey = sshPrivateKey != null ? sshPrivateKey : "";
+        this.httpsUsername = httpsUsername != null ? httpsUsername : "";
+        this.httpsPersonalAccessToken = httpsPersonalAccessToken != null ? httpsPersonalAccessToken : "";
     }
 
     public String getRemoteRepositoryUrl() {
@@ -31,6 +40,14 @@ public class GitSettings {
         this.branchName = branchName;
     }
 
+    public TransportType getTransportType() {
+        return transportType;
+    }
+
+    public void setTransportType(TransportType transportType) {
+        this.transportType = transportType;
+    }
+
     public String getSshPrivateKey() {
         return sshPrivateKey;
     }
@@ -39,9 +56,31 @@ public class GitSettings {
         this.sshPrivateKey = sshPrivateKey;
     }
 
+    public String getHttpsUsername() {
+        return httpsUsername;
+    }
+
+    public void setHttpsUsername(String httpsUsername) {
+        this.httpsUsername = httpsUsername;
+    }
+
+    public String getHttpsPersonalAccessToken() {
+        return httpsPersonalAccessToken;
+    }
+
+    public void setHttpsPersonalAccessToken(String httpsPersonalAccessToken) {
+        this.httpsPersonalAccessToken = httpsPersonalAccessToken;
+    }
+
     public boolean validate() {
-        return !StringUtils.isBlank(remoteRepositoryUrl) &&
-                !StringUtils.isBlank(branchName) &&
-                !StringUtils.isBlank(sshPrivateKey);
+        if (StringUtils.isBlank(remoteRepositoryUrl) || StringUtils.isBlank(branchName)) {
+            return false;
+        }
+
+        if (transportType == TransportType.HTTPS) {
+            return !StringUtils.isBlank(httpsUsername) && !StringUtils.isBlank(httpsPersonalAccessToken);
+        } else {
+            return !StringUtils.isBlank(sshPrivateKey);
+        }
     }
 }

--- a/shared/src/main/java/com/innovarhealthcare/channelHistory/shared/model/TransportType.java
+++ b/shared/src/main/java/com/innovarhealthcare/channelHistory/shared/model/TransportType.java
@@ -1,0 +1,17 @@
+package com.innovarhealthcare.channelHistory.shared.model;
+
+public enum TransportType {
+    SSH,
+    HTTPS;
+
+    public static TransportType fromString(String value) {
+        if (value == null || value.isEmpty()) {
+            return SSH;
+        }
+        try {
+            return TransportType.valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return SSH;
+        }
+    }
+}

--- a/shared/src/main/java/com/innovarhealthcare/channelHistory/shared/model/VersionHistoryProperties.java
+++ b/shared/src/main/java/com/innovarhealthcare/channelHistory/shared/model/VersionHistoryProperties.java
@@ -12,6 +12,9 @@ public class VersionHistoryProperties {
     public static final String VERSION_HISTORY_REMOTE_REPO_URL = "versionHistory.remote.url";
     public static final String VERSION_HISTORY_REMOTE_BRANCH = "versionHistory.remote.branch";
     public static final String VERSION_HISTORY_REMOTE_SSH_KEY = "versionHistory.remote.ssh.key";
+    public static final String VERSION_HISTORY_TRANSPORT_TYPE = "versionHistory.remote.transportType";
+    public static final String VERSION_HISTORY_HTTPS_USERNAME = "versionHistory.remote.https.username";
+    public static final String VERSION_HISTORY_HTTPS_PAT = "versionHistory.remote.https.pat";
 
     private boolean enableVersionHistory;
     private boolean enableAutoCommit;
@@ -26,6 +29,7 @@ public class VersionHistoryProperties {
         enableAutoCommitPrompt = false;
         autoCommitMsg = "";
         enableSyncDelete = false;
+        gitSettings = new GitSettings("", "", "");
     }
 
     public VersionHistoryProperties(Properties properties) {
@@ -44,6 +48,9 @@ public class VersionHistoryProperties {
         properties.setProperty(VERSION_HISTORY_REMOTE_REPO_URL, gitSettings.getRemoteRepositoryUrl());
         properties.setProperty(VERSION_HISTORY_REMOTE_BRANCH, gitSettings.getBranchName());
         properties.setProperty(VERSION_HISTORY_REMOTE_SSH_KEY, gitSettings.getSshPrivateKey());
+        properties.setProperty(VERSION_HISTORY_TRANSPORT_TYPE, gitSettings.getTransportType().name());
+        properties.setProperty(VERSION_HISTORY_HTTPS_USERNAME, gitSettings.getHttpsUsername());
+        properties.setProperty(VERSION_HISTORY_HTTPS_PAT, gitSettings.getHttpsPersonalAccessToken());
 
         return properties;
     }
@@ -89,7 +96,22 @@ public class VersionHistoryProperties {
             sshPrivateKey = properties.getProperty(VERSION_HISTORY_REMOTE_SSH_KEY);
         }
 
-        gitSettings = new GitSettings(remoteRepositoryUrl, branchName, sshPrivateKey);
+        TransportType transportType = TransportType.SSH;
+        if (properties.getProperty(VERSION_HISTORY_TRANSPORT_TYPE) != null && !properties.getProperty(VERSION_HISTORY_TRANSPORT_TYPE).equals("")) {
+            transportType = TransportType.fromString(properties.getProperty(VERSION_HISTORY_TRANSPORT_TYPE));
+        }
+
+        String httpsUsername = "";
+        if (properties.getProperty(VERSION_HISTORY_HTTPS_USERNAME) != null && !properties.getProperty(VERSION_HISTORY_HTTPS_USERNAME).equals("")) {
+            httpsUsername = properties.getProperty(VERSION_HISTORY_HTTPS_USERNAME);
+        }
+
+        String httpsPersonalAccessToken = "";
+        if (properties.getProperty(VERSION_HISTORY_HTTPS_PAT) != null && !properties.getProperty(VERSION_HISTORY_HTTPS_PAT).equals("")) {
+            httpsPersonalAccessToken = properties.getProperty(VERSION_HISTORY_HTTPS_PAT);
+        }
+
+        gitSettings = new GitSettings(remoteRepositoryUrl, branchName, transportType, sshPrivateKey, httpsUsername, httpsPersonalAccessToken);
     }
 
     public boolean isEnableAutoCommit() {


### PR DESCRIPTION
Add support for HTTPS transport protocol for Git operations alongside the existing SSH transport. This enables users to connect to GitLab (and other Git providers) using Personal Access Tokens (PAT) over HTTPS, while maintaining backward compatibility with SSH.

Additionally, update the plugin to support BridgeLink version 4.6.1.

Business Requirements
- Support both SSH and HTTPS transport protocols for Git operations
- Allow users to configure transport type (SSH or HTTPS) via the settings dialog
- For HTTPS transport, require:
  - Username (for authentication) (must be filled, but is not used when no specific username is configured in Gitlab)
  - Personal Access Token (PAT) instead of SSH private key
- Maintain full backward compatibility with existing SSH configuration
- Update plugin compatibility to BridgeLink 4.6.1

This additions are done using AI (Windsurf in combination with Claude Opus 4.5)